### PR TITLE
Fix issue with underscore in title name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19,7 +19,7 @@ var _googleSpreadsheet2 = _interopRequireDefault(_googleSpreadsheet);
 // internally, col titles are much simpler
 // (due to the fact they are XML nodes in gdocs API)
 function getCleanTitle(title) {
-    return title.toLowerCase().replace(/[ #]/gi, '');
+    return title.toLowerCase().replace(/[ #_]/gi, '');
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import GoogleSpreadsheet from 'google-spreadsheet';
 // internally, col titles are much simpler
 // (due to the fact they are XML nodes in gdocs API)
 function getCleanTitle(title) {
-  return title.toLowerCase().replace(/[ #]/gi, '')
+  return title.toLowerCase().replace(/[ #_]/gi, '')
 }
 
 /**


### PR DESCRIPTION
Google Spreadsheet XML also strips any underscores in title names.

Small regexp tweak and problem solved.